### PR TITLE
Fix minor bug in the language selector menu

### DIFF
--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,5 +1,6 @@
 import DefaultTheme from 'vitepress/theme'
 import './styles/fonts.css'
 import './styles/colors.css'
+import './styles/index.css'
 
 export default DefaultTheme

--- a/docs/.vitepress/theme/styles/index.css
+++ b/docs/.vitepress/theme/styles/index.css
@@ -1,3 +1,3 @@
 p.title {
-	padding: 0 10px 0 12px !important;
+  padding: 0 10px 0 12px !important;
 }

--- a/docs/.vitepress/theme/styles/index.css
+++ b/docs/.vitepress/theme/styles/index.css
@@ -1,0 +1,3 @@
+p.title {
+	padding: 0 10px 0 12px !important;
+}


### PR DESCRIPTION
This pull request implements a bug fix that changes the title's padding in the language selector menu, since a part of it was split in two lines. This would appear only on the desktop version of the website. [Here](https://imgur.com/a/F1RZGrP) are two screenshots to show you what I mean.